### PR TITLE
added export_folder as input argument to Session.run_tool()

### DIFF
--- a/ctdvis/callbacks/cbs.py
+++ b/ctdvis/callbacks/cbs.py
@@ -627,7 +627,8 @@ def get_multi_serie_flag_widget(position_source, data_source, datasets,
     return row(button_list, sizing_mode="stretch_width")
 
 
-def get_download_widget(datasets, series, session, key_mapper, savepath):
+def get_download_widget(datasets, series, session, key_mapper, savepath,
+                        export_folder=None):
     """Return a download button."""
     def callback_download(event):
         def serie_generator(selected_keylist):
@@ -645,7 +646,10 @@ def get_download_widget(datasets, series, session, key_mapper, savepath):
             print('len(series.selected.indices)', series.selected.indices)
             return
 
-        path = get_folder_path_from_user()
+        if export_folder:
+            path = export_folder
+        else:
+            path = get_folder_path_from_user()
         if not path:
             print('No download directory selected! '
                   'Using the system standard download '

--- a/ctdvis/session.py
+++ b/ctdvis/session.py
@@ -24,7 +24,7 @@ class Session:
         self.dh.load_profile_data(self.data_directory)
         self.dh.construct_dataframe(self.settings)
 
-    def run_tool(self, tool='qc_smhi', return_layout=False):
+    def run_tool(self, tool='qc_smhi', return_layout=False, export_folder=None):
         """Run the main QC tool (Bokeh)."""
         # TODO settings in yaml-files.. dynamic obj-load..
         plot = QCWorkTool(
@@ -32,6 +32,7 @@ class Session:
             datasets=self.dh.raw_data,
             settings=self.settings,
             ctdpy_session=self.dh.ctd_session,
+            export_folder=export_folder,
         )
         plot.plot_stations()
         plot.plot_data()

--- a/ctdvis/tools/quality_control.py
+++ b/ctdvis/tools/quality_control.py
@@ -57,6 +57,7 @@ class QCWorkTool:
                  settings=None,
                  tabs=None,
                  ctdpy_session=None,
+                 export_folder=False,
                  output_filename="CTD_QC_VIZ.html",
                  output_as_notebook=False,
                  ):
@@ -167,10 +168,11 @@ class QCWorkTool:
         self._setup_flag_widgets()
         self._setup_reset_callback(**xrange_callbacks)
         self._setup_datasource_callbacks()
-        self._setup_download_button(settings.user_download_directory)
+        self._setup_download_button(settings.user_download_directory,
+                                    export_folder=export_folder)
         self._setup_get_file_button()
         self._setup_serie_table()
-        self._setup_info_block()
+        self._setup_info_block(export_folder)
         self._setup_map()
 
         self.ts_axis_ranges = {'t_min': 0, 't_max': 25, 's_min': 2, 's_max': 36}
@@ -245,13 +247,14 @@ class QCWorkTool:
         # self.month_selector.title.text_align = 'center'
         callback.args["month"] = self.month_selector
 
-    def _setup_download_button(self, savepath):
+    def _setup_download_button(self, savepath, export_folder=None):
         """Set download widget."""
         self.download_button = cbs.get_download_widget(self.datasets,
                                                        self.position_plot_source,
                                                        self.ctd_session,
                                                        self.key_ds_mapper,
-                                                       savepath)
+                                                       savepath,
+                                                       export_folder=export_folder)
 
     def _setup_get_file_button(self):
         """Set file button widget."""
@@ -307,10 +310,10 @@ class QCWorkTool:
             comnt_obj=self.comnt_samp,
         )
 
-    def _setup_info_block(self):
+    def _setup_info_block(self, export_folder):
         """Set text block objects."""
         self.info_block = get_info_block()
-        self.text_export = get_export_info_block()
+        self.text_export = get_export_info_block(export_folder)
         self.text_index_selection = standard_block_header(text='Profile index selection', height=30)
         self.text_multi_serie_flagging = standard_block_header(
             text='Multi serie parameter flagging', height=30

--- a/ctdvis/widgets/paragraph.py
+++ b/ctdvis/widgets/paragraph.py
@@ -61,14 +61,24 @@ def get_info_block():
     return Div(text=text, width=200, height=100)
 
 
-def get_export_info_block():
+def get_export_info_block(export_folder):
     """Return Div object."""
-    text = """
-    <h4>Download steps:</h4>
-    <ol>
-      <li>Select series using "map-lasso" or "Shift-table-select"</li>
-      <li>Click on Download below</li>
-    </ol>
-    A folder with datafiles will be downloaded to your computer download-folder (eg. "Hämtade filer")
-    """  # noqa: E501
+    if export_folder:
+        text = f"""
+        <h4>Download steps:</h4>
+        <ol>
+          <li>Select series using "map-lasso" or "Shift-table-select"</li>
+          <li>Click on Download below</li>
+        </ol>
+        Datafiles will be downloaded to your data folder ({export_folder})
+        """  # noqa: E501
+    else:
+        text = """
+        <h4>Download steps:</h4>
+        <ol>
+          <li>Select series using "map-lasso" or "Shift-table-select"</li>
+          <li>Click on Download below</li>
+        </ol>
+        Select a folder for download after clicking on the green button below. If no valid folder is selected, datafiles will be downloaded to your computers download-folder (eg. "Hämtade filer")
+        """  # noqa: E501
     return Div(text=text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-bokeh>=2.3.3
+bokeh
 gsw
 pyproj
 pandas
@@ -8,3 +8,5 @@ ctdpy
 requests
 PyYAML
 setuptools
+yaml
+PyQt5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ ctdpy
 requests
 PyYAML
 setuptools
-yaml
 PyQt5


### PR DESCRIPTION
The user can now pass an export folder when initializing the QC tool.

Example:
```
from ctdvis.session import Session

session = Session(*args, **kwargs)

session.run_tool(
    *args,
    export_folder='EXPORT_FOLDER_PATH',
    **kwargs
)
``` 

